### PR TITLE
Add pull_request trigger on GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   phpunit:

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~8.0",
-        "vimeo/psalm": "~3.7.0",
+        "vimeo/psalm": "^3.7",
         "innmind/black-box": "^4.0"
     },
     "scripts": {


### PR DESCRIPTION
# Changed log

- Using the `pull_request` to be triggered on GitHub action.
- To install latest Psalm version, it should define `^3.7` for `psalm` dependency.
- The GitHub action will be failed until issue #3 has been resolved.