### PR TITLE
Process output should not be kept in memory while writing to the input stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Output generated while writing the input is now directly available (previously it was when the whole input was written)
+
 ## 5.2.1 - 2023-11-11
 
 ### Fixed

--- a/src/Server/Process.php
+++ b/src/Server/Process.php
@@ -6,7 +6,6 @@ namespace Innmind\Server\Control\Server;
 use Innmind\Server\Control\Server\Process\{
     Pid,
     Output,
-    ExitCode,
     TimedOut,
     Failed,
     Signaled,

--- a/src/Server/Process/Background.php
+++ b/src/Server/Process/Background.php
@@ -20,7 +20,7 @@ final class Background implements Process
         // wait for the process to be started in the background otherwise the
         // process will be killed
         // this also allows to send any input to the stream
-        $process->wait();
+        $process->output()->memoize();
         /** @var Sequence<array{0: Str, 1: Output\Type}> */
         $output = Sequence::of();
         $this->output = new Output\Output($output);

--- a/src/Server/Process/Foreground.php
+++ b/src/Server/Process/Foreground.php
@@ -5,12 +5,14 @@ namespace Innmind\Server\Control\Server\Process;
 
 use Innmind\Server\Control\{
     Server\Process,
+    Server\Process\Output\Chunk,
     Exception\RuntimeException,
 };
 use Innmind\Immutable\{
     Sequence,
     Maybe,
     Either,
+    Predicate\Instance,
 };
 
 final class Foreground implements Process
@@ -39,7 +41,7 @@ final class Foreground implements Process
 
                     return $chunk;
                 })
-                ->filter(\is_array(...));
+                ->keep(Instance::of(Chunk::class));
         };
 
         if ($streamOutput) {
@@ -52,7 +54,7 @@ final class Foreground implements Process
             );
         }
 
-        $this->output = new Output\Output($output);
+        $this->output = Output\Output::of($output);
     }
 
     public function pid(): Maybe

--- a/src/Server/Process/Foreground.php
+++ b/src/Server/Process/Foreground.php
@@ -6,7 +6,6 @@ namespace Innmind\Server\Control\Server\Process;
 use Innmind\Server\Control\Server\Process;
 use Innmind\Immutable\{
     Sequence,
-    Str,
     Maybe,
     Either,
 };

--- a/src/Server/Process/Foreground.php
+++ b/src/Server/Process/Foreground.php
@@ -3,7 +3,10 @@ declare(strict_types = 1);
 
 namespace Innmind\Server\Control\Server\Process;
 
-use Innmind\Server\Control\Server\Process;
+use Innmind\Server\Control\{
+    Server\Process,
+    Exception\RuntimeException,
+};
 use Innmind\Immutable\{
     Sequence,
     Maybe,
@@ -66,16 +69,12 @@ final class Foreground implements Process
             $_ = $this->output->foreach(static fn() => null);
         }
 
+        if (\is_null($this->status)) {
+            throw new RuntimeException('Unable to retrieve the status');
+        }
+
         // the status should always be set here because we iterated over the
-        // output above but we stil coalesce to the wait() call to please psalm
-        return $this->status ??= $this
-            ->process
-            ->wait()
-            ->map(fn() => new Success($this->output))
-            ->leftMap(fn($error) => match ($error) {
-                'timed-out' => new TimedOut($this->output),
-                'signaled' => new Signaled($this->output),
-                default => new Failed($error, $this->output),
-            });
+        // output above
+        return $this->status;
     }
 }

--- a/src/Server/Process/Logger.php
+++ b/src/Server/Process/Logger.php
@@ -68,18 +68,18 @@ final class Logger implements Process
             ->wait()
             ->leftMap(function($e) {
                 [$message, $context] = match (\get_class($e)) {
-                    Process\Signaled::class => [
+                    Signaled::class => [
                         'Command {command} stopped due to external signal',
                         ['command' => $this->command->toString()],
                     ],
-                    Process\Failed::class => [
+                    Failed::class => [
                         'Command {command} failed with {exitCode}',
                         [
                             'command' => $this->command->toString(),
                             'exitCode' => $e->exitCode()->toInt(),
                         ],
                     ],
-                    Process\TimedOut::class => [
+                    TimedOut::class => [
                         'Command {command} timed out',
                         ['command' => $this->command->toString()],
                     ],

--- a/src/Server/Process/Output/Chunk.php
+++ b/src/Server/Process/Output/Chunk.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\Server\Control\Server\Process\Output;
+
+use Innmind\Immutable\Str;
+
+/**
+ * @psalm-immutable
+ */
+final class Chunk
+{
+    private function __construct(
+        private Str $data,
+        private Type $type,
+    ) {
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function of(Str $data, Type $type): self
+    {
+        return new self($data, $type);
+    }
+
+    public function data(): Str
+    {
+        return $this->data;
+    }
+
+    public function type(): Type
+    {
+        return $this->type;
+    }
+}

--- a/src/Server/Process/Output/Output.php
+++ b/src/Server/Process/Output/Output.php
@@ -28,6 +28,17 @@ final class Output implements OutputInterface
     }
 
     /**
+     * @param Sequence<Chunk> $chunks
+     */
+    public static function of(Sequence $chunks): self
+    {
+        return new self($chunks->map(static fn($chunk) => [
+            $chunk->data(),
+            $chunk->type(),
+        ]));
+    }
+
+    /**
      * @param callable(Str, Type): void $function
      */
     public function foreach(callable $function): SideEffect

--- a/src/Server/Process/Started.php
+++ b/src/Server/Process/Started.php
@@ -240,7 +240,7 @@ final class Started
             ->content
             ->map(static fn($content) => $content->chunks())
             ->otherwise(function() {
-                $this->closeInput($this->input);
+                $this->closeInput();
 
                 /** @var Maybe<Sequence<Str>> */
                 return Maybe::nothing();
@@ -285,7 +285,7 @@ final class Started
 
                     return $this->readOnce();
                 });
-            $this->closeInput($stream);
+            $this->closeInput();
         })
             ->flatMap(static fn($chunks) => $chunks);
     }
@@ -303,14 +303,14 @@ final class Started
         return $stream;
     }
 
-    private function closeInput(Writable $input): void
+    private function closeInput(): void
     {
         // we crash the app if we fail to close the input stream be cause the
         // underlying process receiving the input may not behave correctly, in
         // some cases this could result on this process hanging forever
         // there is no way to recover safely from unpredictable behaviour so it's
         // better to stop everything
-        $_ = $input->close()->match(
+        $_ = $this->input->close()->match(
             static fn() => null, // closed correctly
             static fn() => throw new RuntimeException('Failed to close input stream'),
         );

--- a/src/Server/Process/Started.php
+++ b/src/Server/Process/Started.php
@@ -32,7 +32,6 @@ use Innmind\Immutable\{
     Either,
     SideEffect,
     Set,
-    Predicate\Instance,
 };
 
 /**
@@ -117,26 +116,6 @@ final class Started
     public function pid(): Pid
     {
         return $this->pid;
-    }
-
-    /**
-     * @return Either<ExitCode|'signaled'|'timed-out', SideEffect>
-     */
-    public function wait(): Either
-    {
-        // we don't need to keep the output read while writing to the input
-        // stream as this data will never be exposed to caller, so by discarding
-        // this data we prevent ourself from reaching a possible "out of memory"
-        // error
-        /** @var Either<ExitCode|'signaled'|'timed-out', SideEffect> */
-        return $this
-            ->output()
-            ->last()
-            ->keep(Instance::of(Either::class))
-            ->match(
-                static fn($return) => $return,
-                static fn() => throw new RuntimeException('Unable to retrieve process result'),
-            );
     }
 
     /**

--- a/src/Server/Processes/Unix.php
+++ b/src/Server/Processes/Unix.php
@@ -15,9 +15,7 @@ use Innmind\Server\Control\{
 };
 use Innmind\TimeContinuum\{
     Clock,
-    ElapsedPeriod,
     Period,
-    Earth,
     Earth\Period\Second,
 };
 use Innmind\TimeWarp\Halt;

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -9,7 +9,6 @@ use Innmind\Server\Control\{
 };
 use Innmind\TimeContinuum\{
     Clock,
-    ElapsedPeriod,
     Period,
 };
 use Innmind\TimeWarp\Halt;

--- a/src/Servers/Unix.php
+++ b/src/Servers/Unix.php
@@ -10,7 +10,6 @@ use Innmind\Server\Control\{
 };
 use Innmind\TimeContinuum\{
     Clock,
-    ElapsedPeriod,
     Period,
 };
 use Innmind\TimeWarp\Halt;

--- a/tests/Server/Process/BackgroundTest.php
+++ b/tests/Server/Process/BackgroundTest.php
@@ -13,14 +13,10 @@ use Innmind\Server\Control\Server\{
 };
 use Innmind\TimeContinuum\Earth\{
     Clock,
-    ElapsedPeriod,
     Period\Second,
 };
 use Innmind\TimeWarp\Halt\Usleep;
-use Innmind\Stream\{
-    Watch\Select,
-    Streams,
-};
+use Innmind\Stream\Streams;
 use PHPUnit\Framework\TestCase;
 
 class BackgroundTest extends TestCase

--- a/tests/Server/Process/ForegroundTest.php
+++ b/tests/Server/Process/ForegroundTest.php
@@ -7,7 +7,6 @@ use Innmind\Server\Control\Server\{
     Process\Foreground,
     Process\Unix,
     Process,
-    Process\Pid,
     Process\Output,
     Process\Output\Type,
     Process\Failed,
@@ -16,14 +15,10 @@ use Innmind\Server\Control\Server\{
 };
 use Innmind\TimeContinuum\Earth\{
     Clock,
-    ElapsedPeriod,
     Period\Second,
 };
 use Innmind\TimeWarp\Halt\Usleep;
-use Innmind\Stream\{
-    Watch\Select,
-    Streams,
-};
+use Innmind\Stream\Streams;
 use Innmind\Immutable\Str;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Server/Process/UnixTest.php
+++ b/tests/Server/Process/UnixTest.php
@@ -46,7 +46,7 @@ class UnixTest extends TestCase
         $count = 0;
         $process = $cat();
 
-        foreach ($process->output() as [$value, $type]) {
+        foreach ($process->output()->filter(\is_array(...))->toList() as [$value, $type]) {
             $this->assertSame(Type::output, $type);
             $this->assertSame("hello\n", $value->toString());
             ++$count;
@@ -74,7 +74,7 @@ class UnixTest extends TestCase
                 $process = $cat();
                 $output = '';
 
-                foreach ($process->output() as [$value, $type]) {
+                foreach ($process->output()->filter(\is_array(...))->toList() as [$value, $type]) {
                     $output .= $value->toString();
                 }
 
@@ -100,7 +100,7 @@ class UnixTest extends TestCase
 
         $this->assertGreaterThanOrEqual(2, $process->pid()->toInt());
 
-        foreach ($process->output() as [$chunk, $type]) {
+        foreach ($process->output()->filter(\is_array(...))->toList() as [$chunk, $type]) {
             $output .= $chunk->toString();
             $this->assertSame($count % 2 === 0 ? Type::output : Type::error, $type);
             ++$count;
@@ -128,7 +128,7 @@ class UnixTest extends TestCase
 
         $this->assertGreaterThanOrEqual(2, $process->pid()->toInt());
 
-        foreach ($process->output() as [$chunk, $type]) {
+        foreach ($process->output()->filter(\is_array(...))->toList() as [$chunk, $type]) {
             $output .= $chunk->toString();
             $this->assertSame($count % 2 === 0 ? Type::output : Type::error, $type);
             ++$count;
@@ -226,7 +226,7 @@ class UnixTest extends TestCase
         );
         $output = '';
 
-        foreach ($cat()->output() as [$value]) {
+        foreach ($cat()->output()->filter(\is_array(...))->toList() as [$value]) {
             $output .= $value->toString();
         }
 

--- a/tests/Server/Process/UnixTest.php
+++ b/tests/Server/Process/UnixTest.php
@@ -167,10 +167,15 @@ class UnixTest extends TestCase
         $started = \microtime(true);
 
         $this->assertGreaterThanOrEqual(2, $process->pid()->toInt());
-        $e = $process->wait()->match(
-            static fn() => null,
-            static fn($e) => $e,
-        );
+        $e = $process
+            ->output()
+            ->last()
+            ->either()
+            ->flatMap(static fn($result) => $result)
+            ->match(
+                static fn() => null,
+                static fn($e) => $e,
+            );
         $this->assertSame('timed-out', $e);
         // 3 because of the grace period
         $this->assertEqualsWithDelta(3, \microtime(true) - $started, 0.5);
@@ -186,10 +191,15 @@ class UnixTest extends TestCase
             Command::foreground('echo')->withArgument('hello'),
         );
 
-        $value = $cat()->wait()->match(
-            static fn($value) => $value,
-            static fn() => null,
-        );
+        $value = $cat()
+            ->output()
+            ->last()
+            ->either()
+            ->flatMap(static fn($result) => $result)
+            ->match(
+                static fn($value) => $value,
+                static fn() => null,
+            );
 
         $this->assertInstanceOf(SideEffect::class, $value);
     }
@@ -206,10 +216,15 @@ class UnixTest extends TestCase
                 ->withEnvironment('PATH', $_SERVER['PATH']),
         );
 
-        $value = $cat()->wait()->match(
-            static fn() => null,
-            static fn($e) => $e,
-        );
+        $value = $cat()
+            ->output()
+            ->last()
+            ->either()
+            ->flatMap(static fn($result) => $result)
+            ->match(
+                static fn() => null,
+                static fn($e) => $e,
+            );
 
         $this->assertInstanceOf(ExitCode::class, $value);
         $this->assertSame(1, $value->toInt());
@@ -257,10 +272,15 @@ class UnixTest extends TestCase
                 ->overwrite(Path::of('test.log')),
         );
 
-        $value = $cat()->wait()->match(
-            static fn($value) => $value,
-            static fn() => null,
-        );
+        $value = $cat()
+            ->output()
+            ->last()
+            ->either()
+            ->flatMap(static fn($result) => $result)
+            ->match(
+                static fn($value) => $value,
+                static fn() => null,
+            );
 
         $this->assertInstanceOf(SideEffect::class, $value);
         $this->assertSame(

--- a/tests/Server/Processes/RemoteTest.php
+++ b/tests/Server/Processes/RemoteTest.php
@@ -10,7 +10,6 @@ use Innmind\Server\Control\Server\{
     Command,
     Signal,
     Process\Pid,
-    Process\ExitCode,
 };
 use Innmind\Url\{
     Path,

--- a/tests/Servers/LoggerTest.php
+++ b/tests/Servers/LoggerTest.php
@@ -8,7 +8,6 @@ use Innmind\Server\Control\{
     Server,
     Server\Processes,
     Server\Process,
-    Server\Process\ExitCode,
     Server\Command,
     Server\Volumes,
 };

--- a/tests/Servers/RemoteTest.php
+++ b/tests/Servers/RemoteTest.php
@@ -8,7 +8,6 @@ use Innmind\Server\Control\{
     Server,
     Server\Processes,
     Server\Process,
-    Server\Process\ExitCode,
     Server\Command,
     Server\Volumes,
 };


### PR DESCRIPTION
## Problem

Fix #4

## Solution

Instead of the low level implementation using generators it now uses lazy `Sequence`s allowing composition that makes output chunks directly available.