### PR TITLE
Fix race condition on process executing too fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- A race condition where a process executing too fast was reported as failing even though it succeeded
+
 ## 5.2.2 - 2024-07-25
 
 ### Fixed

--- a/tests/Server/Processes/UnixTest.php
+++ b/tests/Server/Processes/UnixTest.php
@@ -252,4 +252,23 @@ class UnixTest extends TestCase
         // when done correctly then the foreach above would run forever
         $this->assertTrue(true);
     }
+
+    public function testRegressionWhenProcessFinishesTooFastItsFlaggedAsFailingEvenThoughItSucceeded()
+    {
+        $processes = Unix::of(
+            new Clock,
+            Streams::fromAmbientAuthority(),
+            new Usleep,
+        );
+
+        $this->assertTrue(
+            $processes
+                ->execute(Command::foreground('df')->withShortOption('lh'))
+                ->wait()
+                ->match(
+                    static fn() => true,
+                    static fn() => false,
+                ),
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Right after starting a process we access its status to retrieve its PID. However if the process already finished before accessing the PID then this first call will also return the exit code. This means that when we try to retrieve the exit code when accessing the output then the reported exit code is `-1` indicating it has always been provided in an earlier call.

## Solution

When accessing the status of the process the exit code is cached in a property . If the value is cached it then overwrite any following value return when accessing the status.