### PR TITLE
Reuse workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,71 +3,14 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  phpunit:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest]
-        php-version: ['8.2', '8.3']
-        dependencies: ['lowest', 'highest']
-    name: 'PHPUnit'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: mbstring, intl
-          coverage: xdebug
-      - name: Composer
-        uses: "ramsey/composer-install@v2"
-        with:
-          dependency-versions: ${{ matrix.dependencies }}
-      - name: PHPUnit
-        run: php blackbox.php
-        env:
-          CI: true
-          ENABLE_COVERAGE: 'true'
-      - uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+  blackbox:
+    uses: innmind/github-workflows/.github/workflows/black-box-matrix.yml@main
+  coverage:
+    uses: innmind/github-workflows/.github/workflows/coverage-matrix.yml@main
+    secrets: inherit
   psalm:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version: ['8.2', '8.3']
-        dependencies: ['lowest', 'highest']
-    name: 'Psalm'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: mbstring, intl
-      - name: Composer
-        uses: "ramsey/composer-install@v2"
-        with:
-          dependency-versions: ${{ matrix.dependencies }}
-      - name: Psalm
-        run: vendor/bin/psalm --shepherd
+    uses: innmind/github-workflows/.github/workflows/psalm-matrix.yml@main
   cs:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version: ['8.2']
-    name: 'CS'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: mbstring, intl
-      - name: Composer
-        uses: "ramsey/composer-install@v2"
-      - name: CS
-        run: vendor/bin/php-cs-fixer fix --diff --dry-run
+    uses: innmind/github-workflows/.github/workflows/cs.yml@main
+    with:
+      php-version: '8.2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,13 @@ on: [push, pull_request]
 jobs:
   blackbox:
     uses: innmind/github-workflows/.github/workflows/black-box-matrix.yml@main
+    with:
+      tags: 'ci'
   coverage:
     uses: innmind/github-workflows/.github/workflows/coverage-matrix.yml@main
     secrets: inherit
+    with:
+      tags: 'ci'
   psalm:
     uses: innmind/github-workflows/.github/workflows/psalm-matrix.yml@main
   cs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,11 @@
+name: Create release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    uses: innmind/github-workflows/.github/workflows/release.yml@main
+    secrets: inherit

--- a/tests/Server/Command/AppendTest.php
+++ b/tests/Server/Command/AppendTest.php
@@ -6,9 +6,12 @@ namespace Tests\Innmind\Server\Control\Server\Command;
 use Innmind\Server\Control\Server\Command\Append;
 use Innmind\Url\Path;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class AppendTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $argument = new Append(Path::of('some-value'));

--- a/tests/Server/Command/ArgumentTest.php
+++ b/tests/Server/Command/ArgumentTest.php
@@ -5,9 +5,12 @@ namespace Tests\Innmind\Server\Control\Server\Command;
 
 use Innmind\Server\Control\Server\Command\Argument;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class ArgumentTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $argument = new Argument('some value');
@@ -15,6 +18,8 @@ class ArgumentTest extends TestCase
         $this->assertSame("'some value'", $argument->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testDoesntThrowWhenEmptyArgument()
     {
         $this->assertSame("''", (new Argument(''))->toString());

--- a/tests/Server/Command/OptionTest.php
+++ b/tests/Server/Command/OptionTest.php
@@ -5,9 +5,12 @@ namespace Tests\Innmind\Server\Control\Server\Command;
 
 use Innmind\Server\Control\Server\Command\Option;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class OptionTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testShort()
     {
         $option = Option::short('e');
@@ -21,6 +24,8 @@ class OptionTest extends TestCase
         $this->assertSame("'-e' 'dev'", $option->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testLong()
     {
         $option = Option::long('env');

--- a/tests/Server/Command/OverwriteTest.php
+++ b/tests/Server/Command/OverwriteTest.php
@@ -6,9 +6,12 @@ namespace Tests\Innmind\Server\Control\Server\Command;
 use Innmind\Server\Control\Server\Command\Overwrite;
 use Innmind\Url\Path;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class OverwriteTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $argument = new Overwrite(Path::of('some-value'));

--- a/tests/Server/Command/PipeTest.php
+++ b/tests/Server/Command/PipeTest.php
@@ -5,9 +5,12 @@ namespace Tests\Innmind\Server\Control\Server\Command;
 
 use Innmind\Server\Control\Server\Command\Pipe;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class PipeTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $this->assertSame('|', (new Pipe)->toString());

--- a/tests/Server/Command/StrTest.php
+++ b/tests/Server/Command/StrTest.php
@@ -5,11 +5,16 @@ namespace Tests\Innmind\Server\Control\Server\Command;
 
 use Innmind\Server\Control\Server\Command\Str;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\{
+    DataProvider,
+    Group,
+};
 
 class StrTest extends TestCase
 {
     #[DataProvider('cases')]
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface(string $str, string $expected)
     {
         $this->assertSame($expected, (new Str($str))->toString());

--- a/tests/Server/CommandTest.php
+++ b/tests/Server/CommandTest.php
@@ -11,9 +11,12 @@ use Innmind\Filesystem\File\Content;
 use Innmind\Url\Path;
 use Innmind\Immutable\Map;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class CommandTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $command = Command::foreground('ps');
@@ -30,6 +33,8 @@ class CommandTest extends TestCase
         $this->assertSame('ps', $command->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testBackground()
     {
         $command = Command::background('ps');
@@ -37,6 +42,8 @@ class CommandTest extends TestCase
         $this->assertTrue($command->toBeRunInBackground());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testForeground()
     {
         $command = Command::foreground('ps');
@@ -44,6 +51,8 @@ class CommandTest extends TestCase
         $this->assertFalse($command->toBeRunInBackground());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testWithArgument()
     {
         $command = Command::foreground('echo')
@@ -53,6 +62,8 @@ class CommandTest extends TestCase
         $this->assertSame("echo 'foo'", $command->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testDoesntThrowWhenEmptyArgument()
     {
         $this->assertSame(
@@ -61,6 +72,8 @@ class CommandTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testWithOption()
     {
         $command = Command::foreground('bin/console')
@@ -70,6 +83,8 @@ class CommandTest extends TestCase
         $this->assertSame("bin/console '--env=prod'", $command->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testWithShortOption()
     {
         $command = Command::foreground('bin/console')
@@ -79,6 +94,8 @@ class CommandTest extends TestCase
         $this->assertSame("bin/console '-e' 'prod'", $command->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testWithEnvironment()
     {
         $command = Command::foreground('bin/console')
@@ -94,6 +111,8 @@ class CommandTest extends TestCase
         ));
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testWithEnvironments()
     {
         $command = Command::foreground('bin/console')
@@ -118,6 +137,8 @@ class CommandTest extends TestCase
         ));
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testWithWorkingDirectory()
     {
         $command = Command::foreground('bin/console')
@@ -131,6 +152,8 @@ class CommandTest extends TestCase
         ));
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testWithInput()
     {
         $command = Command::foreground('bin/console')
@@ -145,6 +168,8 @@ class CommandTest extends TestCase
         ));
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testOverwrite()
     {
         $command = Command::foreground('echo')
@@ -154,6 +179,8 @@ class CommandTest extends TestCase
         $this->assertSame("echo 'bar' > 'foo.txt'", $command->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testAppend()
     {
         $command = Command::foreground('echo')
@@ -163,6 +190,8 @@ class CommandTest extends TestCase
         $this->assertSame("echo 'bar' >> 'foo.txt'", $command->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testPipe()
     {
         $commandA = Command::foreground('echo')
@@ -185,6 +214,8 @@ class CommandTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testTimeout()
     {
         $commandA = Command::foreground('echo');

--- a/tests/Server/Process/BackgroundTest.php
+++ b/tests/Server/Process/BackgroundTest.php
@@ -17,9 +17,12 @@ use Innmind\TimeWarp\Halt\Usleep;
 use Innmind\Stream\Streams;
 use Innmind\Immutable\Monoid\Concat;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class BackgroundTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $process = new Unix(
@@ -36,6 +39,8 @@ class BackgroundTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testPid()
     {
         $ps = new Unix(
@@ -53,6 +58,8 @@ class BackgroundTest extends TestCase
         ));
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testOutput()
     {
         $slow = new Unix(
@@ -76,6 +83,8 @@ class BackgroundTest extends TestCase
         $this->assertTrue((\time() - $start) < 1);
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testWait()
     {
         $slow = new Unix(

--- a/tests/Server/Process/ExitCodeTest.php
+++ b/tests/Server/Process/ExitCodeTest.php
@@ -5,9 +5,12 @@ namespace Tests\Innmind\Server\Control\Server\Process;
 
 use Innmind\Server\Control\Server\Process\ExitCode;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class ExitCodeTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testSuccessfulCode()
     {
         $exit = new ExitCode(0);
@@ -17,6 +20,8 @@ class ExitCodeTest extends TestCase
         $this->assertSame('0', $exit->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testErrorCode()
     {
         $exit = new ExitCode(255);

--- a/tests/Server/Process/ForegroundTest.php
+++ b/tests/Server/Process/ForegroundTest.php
@@ -19,9 +19,12 @@ use Innmind\TimeWarp\Halt\Usleep;
 use Innmind\Stream\Streams;
 use Innmind\Immutable\Monoid\Concat;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class ForegroundTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $ps = new Unix(
@@ -38,6 +41,8 @@ class ForegroundTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testPid()
     {
         $ps = new Unix(
@@ -58,6 +63,8 @@ class ForegroundTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testOutput()
     {
         $slow = new Unix(
@@ -94,6 +101,8 @@ class ForegroundTest extends TestCase
         $this->assertSame(6, $count);
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testExitCodeForFailingProcess()
     {
         $fail = new Unix(
@@ -133,6 +142,8 @@ class ForegroundTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testWait()
     {
         $slow = new Unix(
@@ -162,6 +173,8 @@ class ForegroundTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testExitStatusIsKeptInMemory()
     {
         $slow = new Unix(
@@ -180,6 +193,8 @@ class ForegroundTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testExitStatusIsAvailableAfterIteratingOverTheOutput()
     {
         $slow = new Unix(
@@ -204,6 +219,8 @@ class ForegroundTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testOutputIsAvailableAfterWaitingForExitStatus()
     {
         $slow = new Unix(

--- a/tests/Server/Process/Output/TypeTest.php
+++ b/tests/Server/Process/Output/TypeTest.php
@@ -5,14 +5,19 @@ namespace Tests\Innmind\Server\Control\Server\Process\Output;
 
 use Innmind\Server\Control\Server\Process\Output\Type;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class TypeTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testOutput()
     {
         $this->assertSame('stdout', Type::output->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testError()
     {
         $this->assertSame('stderr', Type::error->toString());

--- a/tests/Server/Process/PidTest.php
+++ b/tests/Server/Process/PidTest.php
@@ -5,9 +5,12 @@ namespace Tests\Innmind\Server\Control\Server\Process;
 
 use Innmind\Server\Control\Server\Process\Pid;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class PidTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $pid = new Pid(2);

--- a/tests/Server/Process/UnixTest.php
+++ b/tests/Server/Process/UnixTest.php
@@ -33,11 +33,14 @@ use Innmind\BlackBox\{
     PHPUnit\Framework\TestCase,
     Set,
 };
+use PHPUnit\Framework\Attributes\Group;
 
 class UnixTest extends TestCase
 {
     use BlackBox;
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testSimpleOutput()
     {
         $cat = new Unix(
@@ -60,6 +63,8 @@ class UnixTest extends TestCase
         $this->assertGreaterThanOrEqual(2, $process->pid()->toInt());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testOutput()
     {
         $this
@@ -88,6 +93,8 @@ class UnixTest extends TestCase
             });
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testSlowOutput()
     {
         $slow = new Unix(
@@ -114,6 +121,8 @@ class UnixTest extends TestCase
         $this->assertSame("0\n1\n2\n3\n4\n5\n", $output);
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testTimeoutSlowOutput()
     {
         $slow = new Unix(
@@ -151,6 +160,8 @@ class UnixTest extends TestCase
             ->seconds(2);
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testTimeoutWaitSlowProcess()
     {
         $slow = new Unix(
@@ -184,6 +195,8 @@ class UnixTest extends TestCase
             ->seconds(2);
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testWaitSuccess()
     {
         $cat = new Unix(
@@ -207,6 +220,8 @@ class UnixTest extends TestCase
         $this->assertInstanceOf(SideEffect::class, $value);
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testWaitFail()
     {
         $cat = new Unix(
@@ -233,6 +248,8 @@ class UnixTest extends TestCase
         $this->assertSame(1, $value->toInt());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testWithInput()
     {
         $cat = new Unix(
@@ -258,6 +275,8 @@ class UnixTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testOverwrite()
     {
         @\unlink('test.log');

--- a/tests/Server/Processes/LoggerTest.php
+++ b/tests/Server/Processes/LoggerTest.php
@@ -18,9 +18,12 @@ use Innmind\Stream\Streams;
 use Innmind\Url\Path;
 use Psr\Log\NullLogger;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class LoggerTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $this->assertInstanceOf(
@@ -32,6 +35,8 @@ class LoggerTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testExecute()
     {
         $logger = Logger::psr(
@@ -47,6 +52,8 @@ class LoggerTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testExecuteWithWorkingDirectory()
     {
         $logger = Logger::psr(
@@ -64,6 +71,8 @@ class LoggerTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testKill()
     {
         $logger = Logger::psr(

--- a/tests/Server/Processes/RemoteTest.php
+++ b/tests/Server/Processes/RemoteTest.php
@@ -25,9 +25,12 @@ use Innmind\Immutable\{
     SideEffect,
 };
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class RemoteTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $this->assertInstanceOf(
@@ -40,6 +43,8 @@ class RemoteTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testExecute()
     {
         $remote = new Remote(
@@ -56,6 +61,8 @@ class RemoteTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testExecuteViaSpecificPort()
     {
         $remote = new Remote(
@@ -73,6 +80,8 @@ class RemoteTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testExecuteWithWorkingDirectory()
     {
         $remote = new Remote(
@@ -91,6 +100,8 @@ class RemoteTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testKill()
     {
         $remote = new Remote(
@@ -108,6 +119,8 @@ class RemoteTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testKillViaSpecificPort()
     {
         $remote = new Remote(

--- a/tests/Server/Processes/UnixTest.php
+++ b/tests/Server/Processes/UnixTest.php
@@ -26,9 +26,12 @@ use Innmind\Immutable\{
     Monoid\Concat,
 };
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class UnixTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $this->assertInstanceOf(Processes::class, Unix::of(
@@ -38,6 +41,8 @@ class UnixTest extends TestCase
         ));
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testExecute()
     {
         $processes = Unix::of(
@@ -57,6 +62,8 @@ class UnixTest extends TestCase
         $this->assertTrue((\time() - $start) >= 6);
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testExecuteInBackground()
     {
         $processes = Unix::of(
@@ -77,6 +84,8 @@ class UnixTest extends TestCase
         $this->assertContains('php fixtures/slow.php', $commands);
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testExecuteWithInput()
     {
         $processes = Unix::of(
@@ -102,17 +111,14 @@ class UnixTest extends TestCase
         );
     }
 
+    #[Group('local')]
     public function testKill()
     {
-        if (\PHP_OS === 'Linux') {
-            // for some reason this test doesn't pass for linux in the CI, the
-            // kill tell it succeeded but when checking the process is killed it
-            // is still running
-            // todo investigate more why this is happening only for linux
-            $this->assertTrue(true);
-
-            return;
-        }
+        // For some reason this test doesn't pass for linux in the CI, the
+        // kill tell it succeeded but when checking the process is killed it
+        // is still running. It also sometime fail on macOS.
+        // That's why it's never run in the CI
+        // todo investigate more why this is happening only for linux
 
         $processes = Unix::of(
             new Clock,
@@ -143,6 +149,8 @@ class UnixTest extends TestCase
         $this->assertTrue((\time() - $start) < 2);
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testTimeout()
     {
         $processes = Unix::of(
@@ -168,6 +176,8 @@ class UnixTest extends TestCase
         $this->assertLessThan(3, $start - \time());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testStreamOutput()
     {
         $called = false;
@@ -190,6 +200,8 @@ class UnixTest extends TestCase
         $this->assertTrue($called);
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testSecondCallToStreamedOutputThrowsAnError()
     {
         $called = false;
@@ -211,6 +223,8 @@ class UnixTest extends TestCase
         $process->output()->foreach(static fn() => null);
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testOutputIsNotLostByDefault()
     {
         $called = false;
@@ -234,6 +248,8 @@ class UnixTest extends TestCase
         $this->assertTrue($called);
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testStopProcessEvenWhenPipesAreStillOpenAfterTheProcessBeingKilled()
     {
         @\unlink('/tmp/test-file');
@@ -261,6 +277,8 @@ class UnixTest extends TestCase
         $this->assertTrue(true);
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testRegressionWhenProcessFinishesTooFastItsFlaggedAsFailingEvenThoughItSucceeded()
     {
         $processes = Unix::of(

--- a/tests/Server/Processes/UnixTest.php
+++ b/tests/Server/Processes/UnixTest.php
@@ -104,7 +104,7 @@ class UnixTest extends TestCase
 
     public function testKill()
     {
-        if (\getenv('CI') && \PHP_OS === 'Linux') {
+        if (\PHP_OS === 'Linux') {
             // for some reason this test doesn't pass for linux in the CI, the
             // kill tell it succeeded but when checking the process is killed it
             // is still running

--- a/tests/Server/ScriptTest.php
+++ b/tests/Server/ScriptTest.php
@@ -16,9 +16,12 @@ use Innmind\TimeWarp\Halt\Usleep;
 use Innmind\Stream\Streams;
 use Innmind\Immutable\SideEffect;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class ScriptTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInvokation()
     {
         $script = new Script(
@@ -35,6 +38,8 @@ class ScriptTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testThrowOnFailure()
     {
         $script = new Script(
@@ -51,6 +56,8 @@ class ScriptTest extends TestCase
         $this->assertSame($command2, $e->command());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testOf()
     {
         $script = Script::of('ls', 'ls');
@@ -66,6 +73,8 @@ class ScriptTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testFailDueToTimeout()
     {
         $script = new Script(

--- a/tests/Server/SecondTest.php
+++ b/tests/Server/SecondTest.php
@@ -9,11 +9,14 @@ use Innmind\BlackBox\{
     PHPUnit\Framework\TestCase,
     Set,
 };
+use PHPUnit\Framework\Attributes\Group;
 
 class SecondTest extends TestCase
 {
     use BlackBox;
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testCanBeAnyPositiveValue()
     {
         $this

--- a/tests/Server/SignalTest.php
+++ b/tests/Server/SignalTest.php
@@ -5,45 +5,60 @@ namespace Tests\Innmind\Server\Control\Server;
 
 use Innmind\Server\Control\Server\Signal;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class SignalTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testHangUp()
     {
         $this->assertSame(\SIGHUP, Signal::hangUp->toInt());
         $this->assertSame((string) \SIGHUP, Signal::hangUp->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterrupt()
     {
         $this->assertSame(\SIGINT, Signal::interrupt->toInt());
         $this->assertSame((string) \SIGINT, Signal::interrupt->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testQuit()
     {
         $this->assertSame(\SIGQUIT, Signal::quit->toInt());
         $this->assertSame((string) \SIGQUIT, Signal::quit->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testAbort()
     {
         $this->assertSame(\SIGABRT, Signal::abort->toInt());
         $this->assertSame((string) \SIGABRT, Signal::abort->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testKill()
     {
         $this->assertSame(\SIGKILL, Signal::kill->toInt());
         $this->assertSame((string) \SIGKILL, Signal::kill->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testAlarm()
     {
         $this->assertSame(\SIGALRM, Signal::alarm->toInt());
         $this->assertSame((string) \SIGALRM, Signal::alarm->toString());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testTerminate()
     {
         $this->assertSame(\SIGTERM, Signal::terminate->toInt());

--- a/tests/Server/Volumes/NameTest.php
+++ b/tests/Server/Volumes/NameTest.php
@@ -9,11 +9,14 @@ use Innmind\BlackBox\{
     PHPUnit\Framework\TestCase,
     Set,
 };
+use PHPUnit\Framework\Attributes\Group;
 
 class NameTest extends TestCase
 {
     use BlackBox;
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $this

--- a/tests/Server/Volumes/UnixTest.php
+++ b/tests/Server/Volumes/UnixTest.php
@@ -23,9 +23,12 @@ use Innmind\Immutable\{
     SideEffect,
 };
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class UnixTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $this->assertInstanceOf(
@@ -36,6 +39,8 @@ class UnixTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testMountOSXVolume()
     {
         $volumes = new Unix(
@@ -57,6 +62,8 @@ class UnixTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testThrowWhenFailToMountOSXVolume()
     {
         $volumes = new Unix(
@@ -78,6 +85,8 @@ class UnixTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testUnmountOSXVolume()
     {
         $volumes = new Unix(
@@ -96,6 +105,8 @@ class UnixTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testReturnErrorWhenFailToUnmountOSXVolume()
     {
         $volumes = new Unix(
@@ -114,6 +125,8 @@ class UnixTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testMountLinuxVolume()
     {
         $volumes = new Unix(
@@ -135,6 +148,8 @@ class UnixTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testReturnErrorWhenFailToMountLinuxVolume()
     {
         $volumes = new Unix(
@@ -156,6 +171,8 @@ class UnixTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testUnmountLinuxVolume()
     {
         $volumes = new Unix(
@@ -174,6 +191,8 @@ class UnixTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testReturnErrorWhenFailToUnmountLinuxVolume()
     {
         $volumes = new Unix(

--- a/tests/ServerFactoryTest.php
+++ b/tests/ServerFactoryTest.php
@@ -12,9 +12,12 @@ use Innmind\TimeContinuum\Earth\Clock;
 use Innmind\TimeWarp\Halt\Usleep;
 use Innmind\Stream\Streams;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class ServerFactoryTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testMakeUnix()
     {
         if (!\in_array(\PHP_OS, ['Darwin', 'Linux'], true)) {
@@ -30,6 +33,8 @@ class ServerFactoryTest extends TestCase
         ));
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testThrowWhenUnsupportedOperatingSystem()
     {
         if (\in_array(\PHP_OS, ['Darwin', 'Linux'], true)) {

--- a/tests/Servers/LoggerTest.php
+++ b/tests/Servers/LoggerTest.php
@@ -23,9 +23,12 @@ use Innmind\Immutable\{
 };
 use Psr\Log\NullLogger;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class LoggerTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $this->assertInstanceOf(
@@ -37,6 +40,8 @@ class LoggerTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testProcesses()
     {
         $server = $this->server('ls');
@@ -53,6 +58,8 @@ class LoggerTest extends TestCase
         $logger->processes()->execute(Command::foreground('ls'));
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testVolumes()
     {
         $server = $this->server('which diskutil', "diskutil 'unmount' '/dev'");
@@ -69,6 +76,8 @@ class LoggerTest extends TestCase
         $logger->volumes()->unmount(new Volumes\Name('/dev'));
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testReboot()
     {
         $server = $this->server('sudo shutdown -r now');
@@ -87,6 +96,8 @@ class LoggerTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testShutdown()
     {
         $server = $this->server('sudo shutdown -h now');

--- a/tests/Servers/RemoteTest.php
+++ b/tests/Servers/RemoteTest.php
@@ -27,9 +27,12 @@ use Innmind\Immutable\{
     SideEffect,
 };
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class RemoteTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $this->assertInstanceOf(
@@ -42,6 +45,8 @@ class RemoteTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testProcesses()
     {
         $server = $this->server("ssh 'foo@example.com' 'ls'");
@@ -59,6 +64,8 @@ class RemoteTest extends TestCase
         $remote->processes()->execute(Command::foreground('ls'));
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testProcessesViaSpecificPort()
     {
         $server = $this->server("ssh '-p' '42' 'foo@example.com' 'ls'");
@@ -77,6 +84,8 @@ class RemoteTest extends TestCase
         $remote->processes()->execute(Command::foreground('ls'));
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testVolumes()
     {
         $server = $this->server(
@@ -97,6 +106,8 @@ class RemoteTest extends TestCase
         $remote->volumes()->unmount(new Volumes\Name('/dev'));
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testReboot()
     {
         $server = $this->server("ssh 'foo@example.com' 'sudo shutdown -r now'");
@@ -116,6 +127,8 @@ class RemoteTest extends TestCase
         );
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testShutdown()
     {
         $server = $this->server("ssh 'foo@example.com' 'sudo shutdown -h now'");

--- a/tests/Servers/UnixTest.php
+++ b/tests/Servers/UnixTest.php
@@ -13,9 +13,12 @@ use Innmind\TimeContinuum\Earth\Clock;
 use Innmind\TimeWarp\Halt\Usleep;
 use Innmind\Stream\Streams;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class UnixTest extends TestCase
 {
+    #[Group('ci')]
+    #[Group('local')]
     public function testInterface()
     {
         $this->assertInstanceOf(Server::class, Unix::of(
@@ -25,6 +28,8 @@ class UnixTest extends TestCase
         ));
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testProcesses()
     {
         $this->assertInstanceOf(Processes::class, Unix::of(
@@ -34,6 +39,8 @@ class UnixTest extends TestCase
         )->processes());
     }
 
+    #[Group('ci')]
+    #[Group('local')]
     public function testVolumes()
     {
         $this->assertInstanceOf(Volumes::class, Unix::of(


### PR DESCRIPTION
The `UnixTest::testKill()` has been disabled in the CI has it often fails (see the code comment).

To do this tags have been specified on all tests, hence the big diff.